### PR TITLE
separate data collection from reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ output/*/index.html
 # Sphinx
 docs/_build
 readme-errors
+djpt.results_collected

--- a/README.rst
+++ b/README.rst
@@ -211,6 +211,7 @@ as the app has defaults that include all limits.
 
 Release Notes
 =============
+* 0.7.0
 
 * 0.6.1
 

--- a/README.rst
+++ b/README.rst
@@ -42,16 +42,13 @@ Usage
 * set your limits (see below for detail)
 * and run your test ``manage.py test <your app>``
 
-For any limit violations, there will be a test failure, and at the end, a
-`Worst Items Report` will be printed (unless supressed by
-``settins.DJPT_PRINT_WORST_REPORT = False``). If it is desired to control
-this behavior from the command line, the recommendation is to define it
-through environmnet variables (a'la
-`12 factor <https://12factor.net/config>`_), i.e.:
+For any limit violations, there will be a test failure.
 
- * in ``settings.py``, ``DJPT_PRINT_WORST_REPORT = bool(int(os.environ.get('DJPT_PRINT_WORST_REPORT',  '1')))``
- * from the command line, run the tests like
-   ``DJPT_PRINT_WORST_REPORT=0 manage.py test <your app>``
+After the test run, you could generate the `Worst Items Report`
+by running ``manage.py djpt_worst_report``.
+
+The data is collected into ``settings.DJPT_DATAFILE_PATH`` file,
+or into ``djpt.results_collected``.
 
 
 Supported Limits
@@ -211,12 +208,17 @@ as the app has defaults that include all limits.
 
 Release Notes
 =============
-* 0.7.0
-  
+* 0.7.0 - separate data collection and reporting
+
+  * introduce ``djpt_worst_report`` management command
+
   * backwards incompatibe changes:
 
     * Collectors are expected to have ``get_sample_results`` method to allow easier and 
       more realistic testing
+    * Worst Items Report is not printed anymore after the test run.
+    * ``settings.DJPT_PRINT_WORST_REPORT`` doesn't have much effect anymore, will be
+      dropped in a subsequent release
 
 
 * 0.6.1

--- a/README.rst
+++ b/README.rst
@@ -212,6 +212,12 @@ as the app has defaults that include all limits.
 Release Notes
 =============
 * 0.7.0
+  
+  * backwards incompatibe changes:
+
+    * Collectors are expected to have ``get_sample_results`` method to allow easier and 
+      more realistic testing
+
 
 * 0.6.1
 

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,10 +1,25 @@
+separate data collection from reporting
+---------------------------------------
+
+* write and test serializer of results from signal
+  * serializer reading back should also just fire signal results_collected
+    but should have a different name to avoid problems and to be explicit
+* test that during thestrun, serializer is connected to the signal
+* change worst_report to use the new signal
+* assert worstreport/report is not subscribed to results_collected signal
+
+* support multiple runs generating different files and combining them
+
+* write bang_for_the_buck report on what to improve first 
+
+---------------------------------------
 use for template tags
 rename limits settings to be consistent with the DJPT_ prefix
    add deprecation warning for old style
    should I also update the tests to run both versions?
 
 future, out of scope now for registry
---------------------------------------
+---------------------------------------
 need to write settings_changed_handler too
 use it for app ready integration points, simplifying integrate_** methods
     should use runtime value of settings

--- a/TODO.txt
+++ b/TODO.txt
@@ -5,9 +5,12 @@ separate data collection from reporting
   * serializer reading back should also just fire signal results_collected
     but should have a different name to avoid problems and to be explicit
 * test that during thestrun, serializer is connected to the signal
+* use a setting for output path
 * change worst_report to use the new signal
 * assert worstreport/report is not subscribed to results_collected signal
 * add deprecation warning for DJPT_SHOW_WORST_REPORT setting
+* make sure that the serializer copies the context dict
+* introduce a command to run/display reports and remove inlined one
 
 * support multiple runs generating different files and combining them
 

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,15 +1,6 @@
 separate data collection from reporting
 ---------------------------------------
 
-* write and test serializer of results from signal
-  * serializer reading back should also just fire signal results_collected
-    but should have a different name to avoid problems and to be explicit
-* test that during thestrun, serializer is connected to the signal
-* use a setting for output path
-* change worst_report to use the new signal
-* assert worstreport/report is not subscribed to results_collected signal
-* add deprecation warning for DJPT_SHOW_WORST_REPORT setting
-* make sure that the serializer copies the context dict
 * introduce a command to run/display reports and remove inlined one
 
 * support multiple runs generating different files and combining them

--- a/TODO.txt
+++ b/TODO.txt
@@ -2,12 +2,6 @@ separate data collection from reporting
 ---------------------------------------
 
 * write and test serializer of results from signal
-  * how to be sure that all result types can be used?
-    introdcue a collector method to provide sample results
-    - to be used in tests
-    - could also be used by users to test their signal handlers/reports
-    - each result is assumed to return a list of objects where each can
-      be tested through standard == equality checks
   * serializer reading back should also just fire signal results_collected
     but should have a different name to avoid problems and to be explicit
 * test that during thestrun, serializer is connected to the signal

--- a/TODO.txt
+++ b/TODO.txt
@@ -7,6 +7,7 @@ separate data collection from reporting
 * test that during thestrun, serializer is connected to the signal
 * change worst_report to use the new signal
 * assert worstreport/report is not subscribed to results_collected signal
+* add deprecation warning for DJPT_SHOW_WORST_REPORT setting
 
 * support multiple runs generating different files and combining them
 

--- a/TODO.txt
+++ b/TODO.txt
@@ -2,6 +2,12 @@ separate data collection from reporting
 ---------------------------------------
 
 * write and test serializer of results from signal
+  * how to be sure that all result types can be used?
+    introdcue a collector method to provide sample results
+    - to be used in tests
+    - could also be used by users to test their signal handlers/reports
+    - each result is assumed to return a list of objects where each can
+      be tested through standard == equality checks
   * serializer reading back should also just fire signal results_collected
     but should have a different name to avoid problems and to be explicit
 * test that during thestrun, serializer is connected to the signal

--- a/django_performance_testing/__init__.py
+++ b/django_performance_testing/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.7.0-dev'
+__version__ = '0.7.0'
 
 default_app_config = \
     'django_performance_testing.apps.DjangoPerformanceTestingAppConfig'

--- a/django_performance_testing/__init__.py
+++ b/django_performance_testing/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.6.1'
+__version__ = '0.7.0-dev'
 
 default_app_config = \
     'django_performance_testing.apps.DjangoPerformanceTestingAppConfig'

--- a/django_performance_testing/management/commands/djpt_worst_report.py
+++ b/django_performance_testing/management/commands/djpt_worst_report.py
@@ -1,0 +1,18 @@
+from django.core.management.base import BaseCommand
+from django_performance_testing.reports import WorstReport
+from django_performance_testing.serializer import \
+    get_datafile_path, Reader
+
+
+class Command(BaseCommand):
+    help = """
+    DJPT command to print the worst performing items based on the
+    vailable collectors
+    """
+
+    def handle(self, *args, **kwargs):
+        self.report = WorstReport()
+        datafile_path = get_datafile_path()
+        reader = Reader(datafile_path)
+        reader.read_all()
+        self.report.render(self.stdout)

--- a/django_performance_testing/reports.py
+++ b/django_performance_testing/reports.py
@@ -34,6 +34,7 @@ class WorstReport(object):
             d = get_data(sender.id_, sender.type_name)
             current = d.get(name, None)
             if current is None or current.value < result:
+                # TODO: once serialization, no need to deepcopy
                 d[name] = Result(value=result, context=copy.deepcopy(context))
 
         for name, result in name_value_pairs:

--- a/django_performance_testing/reports.py
+++ b/django_performance_testing/reports.py
@@ -1,6 +1,6 @@
 import copy
 from django.utils import six
-from django_performance_testing.signals import results_collected
+from django_performance_testing.signals import results_read
 import pprint
 
 
@@ -16,7 +16,7 @@ class Result(object):
 class WorstReport(object):
 
     def __init__(self):
-        results_collected.connect(self.handle_results_collected)
+        results_read.connect(self.handle_results_collected)
         self.data = {}
 
     def handle_results_collected(self, signal, sender, results, context, **kw):

--- a/django_performance_testing/serializer.py
+++ b/django_performance_testing/serializer.py
@@ -1,4 +1,5 @@
 from django.utils.six.moves import cPickle as pickle
+from django_performance_testing.signals import results_collected
 
 
 class Reader:
@@ -18,11 +19,15 @@ class Writer:
     def start(self):
         self.f = open(self.fpath, 'wb')
         self.data = []
+        results_collected.connect(self.handle_results_collected)
 
     def end(self):
         data = pickle.dumps(self.data, pickle.HIGHEST_PROTOCOL)
         self.f.write(data)
         self.f.close()
+
+    def handle_results_collected(self, sender, results, context, **kwargs):
+        self.handle_result(sender, results, context)
 
     def handle_result(self, sender, result, context):
         self.data.append((sender, result, context))

--- a/django_performance_testing/serializer.py
+++ b/django_performance_testing/serializer.py
@@ -24,5 +24,5 @@ class Writer:
         self.f.write(data)
         self.f.close()
 
-    def handle_result(self, sender, result):
-        self.data.append((sender, result))
+    def handle_result(self, sender, result, context):
+        self.data.append((sender, result, context))

--- a/django_performance_testing/serializer.py
+++ b/django_performance_testing/serializer.py
@@ -1,0 +1,28 @@
+from django.utils.six.moves import cPickle as pickle
+
+
+class Reader:
+    def __init__(self, fpath):
+        self.fpath = fpath
+
+    def read_all(self):
+        with open(self.fpath, 'rb') as f:
+            data = f.read()
+        return pickle.loads(data)
+
+
+class Writer:
+    def __init__(self, fpath):
+        self.fpath = fpath
+
+    def start(self):
+        self.f = open(self.fpath, 'wb')
+        self.data = []
+
+    def end(self):
+        data = pickle.dumps(self.data, pickle.HIGHEST_PROTOCOL)
+        self.f.write(data)
+        self.f.close()
+
+    def handle_result(self, sender, result):
+        self.data.append((sender, result))

--- a/django_performance_testing/serializer.py
+++ b/django_performance_testing/serializer.py
@@ -19,14 +19,14 @@ class Writer:
         self.fpath = fpath
 
     def start(self):
-        self.f = open(self.fpath, 'wb')  # TODO: move it to end
         self.data = []
         results_collected.connect(self.handle_results_collected)
 
     def end(self):
         data = pickle.dumps(self.data, pickle.HIGHEST_PROTOCOL)
-        self.f.write(data)
-        self.f.close()
+        # TODO: couldn't write a test to verify file is opened only here
+        with open(self.fpath, 'wb') as f:
+            f.write(data)
 
     def handle_results_collected(self, sender, results, context, **kwargs):
         self.handle_result(sender, results, context)

--- a/django_performance_testing/serializer.py
+++ b/django_performance_testing/serializer.py
@@ -4,12 +4,12 @@ from django_performance_testing.signals import results_collected, results_read
 
 DEFAULT_DJPT_DATAFILE_PATH = 'djpt.results_collected'
 
+
 def get_datafile_path():
     try:
         return settings.DJPT_DATAFILE_PATH
     except AttributeError:
         return DEFAULT_DJPT_DATAFILE_PATH
-
 
 
 class Reader:

--- a/django_performance_testing/serializer.py
+++ b/django_performance_testing/serializer.py
@@ -9,6 +9,8 @@ class Reader:
     def read_all(self):
         with open(self.fpath, 'rb') as f:
             data = f.read()
+        if not data:
+            return []
         return pickle.loads(data)
 
 

--- a/django_performance_testing/serializer.py
+++ b/django_performance_testing/serializer.py
@@ -1,5 +1,15 @@
+from django.conf import settings
 from django.utils.six.moves import cPickle as pickle
 from django_performance_testing.signals import results_collected, results_read
+
+DEFAULT_DJPT_DATAFILE_PATH = 'djpt.results_collected'
+
+def get_datafile_path():
+    try:
+        return settings.DJPT_DATAFILE_PATH
+    except AttributeError:
+        return DEFAULT_DJPT_DATAFILE_PATH
+
 
 
 class Reader:

--- a/django_performance_testing/serializer.py
+++ b/django_performance_testing/serializer.py
@@ -17,7 +17,7 @@ class Writer:
         self.fpath = fpath
 
     def start(self):
-        self.f = open(self.fpath, 'wb')
+        self.f = open(self.fpath, 'wb')  # TODO: move it to end
         self.data = []
         results_collected.connect(self.handle_results_collected)
 
@@ -29,5 +29,5 @@ class Writer:
     def handle_results_collected(self, sender, results, context, **kwargs):
         self.handle_result(sender, results, context)
 
-    def handle_result(self, sender, result, context):
-        self.data.append((sender, result, context))
+    def handle_result(self, sender, results, context):
+        self.data.append((sender, results, context))

--- a/django_performance_testing/serializer.py
+++ b/django_performance_testing/serializer.py
@@ -1,5 +1,5 @@
 from django.utils.six.moves import cPickle as pickle
-from django_performance_testing.signals import results_collected
+from django_performance_testing.signals import results_collected, results_read
 
 
 class Reader:
@@ -11,7 +11,10 @@ class Reader:
             data = f.read()
         if not data:
             return []
-        return pickle.loads(data)
+        deserialized = pickle.loads(data)
+        for (sender, results, context) in deserialized:
+            results_read.send(sender=sender, results=results, context=context)
+        return deserialized
 
 
 class Writer:

--- a/django_performance_testing/serializer.py
+++ b/django_performance_testing/serializer.py
@@ -23,6 +23,7 @@ class Writer:
         results_collected.connect(self.handle_results_collected)
 
     def end(self):
+        results_collected.disconnect(self.handle_results_collected)
         data = pickle.dumps(self.data, pickle.HIGHEST_PROTOCOL)
         # TODO: couldn't write a test to verify file is opened only here
         with open(self.fpath, 'wb') as f:

--- a/django_performance_testing/signals.py
+++ b/django_performance_testing/signals.py
@@ -4,3 +4,5 @@ from django.dispatch import Signal
 results_collected = Signal(providing_args=('results', 'context'))
 
 before_clearing_queries_log = Signal(providing_args=['queries'])
+
+results_read = Signal(providing_args=('results', 'context'))

--- a/django_performance_testing/test_runner.py
+++ b/django_performance_testing/test_runner.py
@@ -1,6 +1,7 @@
 # TODO: app.ready happens before the command is imported - how to test?
 from django.conf import settings
 from django.test import utils
+from django_performance_testing.serializer import Writer
 from django_performance_testing.reports import WorstReport
 from django_performance_testing.utils import \
     multi_context_manager, wrap_cls_method_in_ctx_manager
@@ -23,7 +24,13 @@ class DjptTestRunnerMixin(object):
             need to override run() to print things after
         """
         self.djpt_worst_report = WorstReport()
+        datafile_path = getattr(settings, 'DJPT_DATAFILE_PATH', None)
+        if datafile_path:
+            self.djpt_writer = Writer(datafile_path)
+            self.djpt_writer.start()
         retval = super(DjptTestRunnerMixin, self).run(*a, **kw)
+        if datafile_path:
+            self.djpt_writer.end()
         if getattr(settings, 'DJPT_PRINT_WORST_REPORT', True):
             self.djpt_worst_report.render(self.stream)
         return retval

--- a/django_performance_testing/test_runner.py
+++ b/django_performance_testing/test_runner.py
@@ -1,5 +1,4 @@
 # TODO: app.ready happens before the command is imported - how to test?
-from django.core.management import call_command
 from django.conf import settings
 from django.test import utils
 from django_performance_testing.serializer import \
@@ -30,7 +29,9 @@ class DjptTestRunnerMixin(object):
         retval = super(DjptTestRunnerMixin, self).run(*a, **kw)
         self.djpt_writer.end()
         if getattr(settings, 'DJPT_PRINT_WORST_REPORT', True):
-            call_command('djpt_worst_report', stdout=self.stream)
+            self.stream.write(
+                'To see the Worst Performing Items report, '
+                'run manage.py djpt_worst_report')
         return retval
 
 

--- a/django_performance_testing/test_runner.py
+++ b/django_performance_testing/test_runner.py
@@ -1,9 +1,9 @@
 # TODO: app.ready happens before the command is imported - how to test?
+from django.core.management import call_command
 from django.conf import settings
 from django.test import utils
 from django_performance_testing.serializer import \
-    Writer, get_datafile_path, Reader
-from django_performance_testing.reports import WorstReport
+    Writer, get_datafile_path
 from django_performance_testing.utils import \
     multi_context_manager, wrap_cls_method_in_ctx_manager
 from django_performance_testing.context import scoped_context
@@ -24,16 +24,13 @@ class DjptTestRunnerMixin(object):
             as self.stopTestRun is ran before the actual results were printed,
             need to override run() to print things after
         """
-        self.djpt_worst_report = WorstReport()
         datafile_path = get_datafile_path()
         self.djpt_writer = Writer(datafile_path)
         self.djpt_writer.start()
         retval = super(DjptTestRunnerMixin, self).run(*a, **kw)
         self.djpt_writer.end()
-        reader = Reader(datafile_path)
-        reader.read_all()
         if getattr(settings, 'DJPT_PRINT_WORST_REPORT', True):
-            self.djpt_worst_report.render(self.stream)
+            call_command('djpt_worst_report', stdout=self.stream)
         return retval
 
 

--- a/django_performance_testing/test_runner.py
+++ b/django_performance_testing/test_runner.py
@@ -1,7 +1,8 @@
 # TODO: app.ready happens before the command is imported - how to test?
 from django.conf import settings
 from django.test import utils
-from django_performance_testing.serializer import Writer
+from django_performance_testing.serializer import \
+    Writer, get_datafile_path, Reader
 from django_performance_testing.reports import WorstReport
 from django_performance_testing.utils import \
     multi_context_manager, wrap_cls_method_in_ctx_manager
@@ -24,13 +25,13 @@ class DjptTestRunnerMixin(object):
             need to override run() to print things after
         """
         self.djpt_worst_report = WorstReport()
-        datafile_path = getattr(settings, 'DJPT_DATAFILE_PATH', None)
-        if datafile_path:
-            self.djpt_writer = Writer(datafile_path)
-            self.djpt_writer.start()
+        datafile_path = get_datafile_path()
+        self.djpt_writer = Writer(datafile_path)
+        self.djpt_writer.start()
         retval = super(DjptTestRunnerMixin, self).run(*a, **kw)
-        if datafile_path:
-            self.djpt_writer.end()
+        self.djpt_writer.end()
+        reader = Reader(datafile_path)
+        reader.read_all()
         if getattr(settings, 'DJPT_PRINT_WORST_REPORT', True):
             self.djpt_worst_report.render(self.stream)
         return retval

--- a/django_performance_testing/timing.py
+++ b/django_performance_testing/timing.py
@@ -14,6 +14,10 @@ class TimeCollector(BaseCollector):
     def get_results_to_send(self):
         return [NameValueResult(name='total', value=time() - self.start)]
 
+    @classmethod
+    def get_sample_results(cls):
+        return [0.01, 1.00, 3.2]
+
 
 class TimeLimit(BaseLimit):
     collector_cls = TimeCollector

--- a/proof-of-concepts/pytest-fixtures-plugins-providing-sample-data-being-converted-to-fixtures-themselves.py
+++ b/proof-of-concepts/pytest-fixtures-plugins-providing-sample-data-being-converted-to-fixtures-themselves.py
@@ -30,7 +30,7 @@ def pytest_generate_tests(metafunc):
         for plugin_cls in plugin_cls_fixture.params:
             for i, sample in enumerate(plugin_cls.get_sample_results()):
                 sample_results.append((plugin_cls, sample))
-                ids.append(str(i))
+                ids.append('-sample{}-'.format(i))
         metafunc.parametrize(
             argnames='plugin_cls_with_sample_result',
             argvalues=sample_results,

--- a/proof-of-concepts/pytest-fixtures-plugins-providing-sample-data-being-converted-to-fixtures-themselves.py
+++ b/proof-of-concepts/pytest-fixtures-plugins-providing-sample-data-being-converted-to-fixtures-themselves.py
@@ -1,0 +1,45 @@
+import pytest
+
+
+class First:
+
+    @classmethod
+    def get_sample_results(cls):
+        return [['first', '1'], ['first', '2']]
+
+
+class Second:
+
+    @classmethod
+    def get_sample_results(cls):
+        return [['second', '1'], ['second', '2']]
+
+
+@pytest.fixture(params=[First, Second])
+def plugin_cls(request):
+    return request.param
+
+
+def pytest_generate_tests(metafunc):
+    if 'plugin_cls_with_sample_result' in metafunc.fixturenames:
+        plugin_cls_fixtures = metafunc._arg2fixturedefs['plugin_cls']
+        assert len(plugin_cls_fixtures) == 1
+        plugin_cls_fixture = plugin_cls_fixtures[0]
+        sample_results = []
+        ids = []
+        for plugin_cls in plugin_cls_fixture.params:
+            for i, sample in enumerate(plugin_cls.get_sample_results()):
+                sample_results.append((plugin_cls, sample))
+                ids.append(str(i))
+        metafunc.parametrize(
+            argnames='plugin_cls_with_sample_result',
+            argvalues=sample_results,
+            ids=ids
+        )
+
+def test_roundtrip_serialization(plugin_cls, plugin_cls_with_sample_result):
+    if plugin_cls != plugin_cls_with_sample_result[0]:
+        pytest.skip('this sample result is not for this plugin')
+    sample_result = plugin_cls_with_sample_result[-1]
+    assert False
+

--- a/proof-of-concepts/pytest-fixtures-plugins-providing-sample-data-being-converted-to-fixtures-themselves.py
+++ b/proof-of-concepts/pytest-fixtures-plugins-providing-sample-data-being-converted-to-fixtures-themselves.py
@@ -45,6 +45,6 @@ def sample_result(request, plugin_cls, plugin_cls_with_sample_result):
     result = plugin_cls_with_sample_result[-1]
     return result
 
+
 def test_roundtrip_serialization(sample_result):
     assert False
-

--- a/proof-of-concepts/pytest-fixtures-plugins-providing-sample-data-being-converted-to-fixtures-themselves.py
+++ b/proof-of-concepts/pytest-fixtures-plugins-providing-sample-data-being-converted-to-fixtures-themselves.py
@@ -37,9 +37,14 @@ def pytest_generate_tests(metafunc):
             ids=ids
         )
 
-def test_roundtrip_serialization(plugin_cls, plugin_cls_with_sample_result):
+
+@pytest.fixture
+def sample_result(request, plugin_cls, plugin_cls_with_sample_result):
     if plugin_cls != plugin_cls_with_sample_result[0]:
         pytest.skip('this sample result is not for this plugin')
-    sample_result = plugin_cls_with_sample_result[-1]
+    result = plugin_cls_with_sample_result[-1]
+    return result
+
+def test_roundtrip_serialization(sample_result):
     assert False
 

--- a/tests/testapp/test_helpers.py
+++ b/tests/testapp/test_helpers.py
@@ -9,10 +9,8 @@ from django_performance_testing.signals import results_collected
 FakeSender = namedtuple('FakeSender', ('id_', 'type_name'))
 
 
-class WithId(FakeSender):
-
-    def __new__(cls, id_):
-        return super(WithId, cls).__new__(cls, id_, 'type name')
+def WithId(id_):
+    return FakeSender(id_, 'type name')
 
 
 class RunnerTestCasePackage(object):

--- a/tests/testapp/tests/conftest.py
+++ b/tests/testapp/tests/conftest.py
@@ -1,3 +1,5 @@
+import os
+import tempfile
 import pytest
 from django_performance_testing.queries import QueryCollector, QueryBatchLimit
 from django_performance_testing.timing import TimeCollector, TimeLimit
@@ -27,3 +29,11 @@ def limit_cls_and_name_to_id(fixture_value):
     ], ids=limit_cls_and_name_to_id)
 def limit_cls_and_name(request):
     yield request.param
+
+
+@pytest.fixture
+def tmpfilepath():
+    fd, fname = tempfile.mkstemp(prefix='djpt-test-')
+    os.close(fd)
+    yield fname
+    os.remove(fname)

--- a/tests/testapp/tests/test_core_infrastructure.py
+++ b/tests/testapp/tests/test_core_infrastructure.py
@@ -104,6 +104,11 @@ class TestCollectors(object):
         finally:
             results_collected.disconnect(failing_signal_handler)
 
+    def test_has_a_method_providing_sample_result(self, collector_cls):
+        sample_results = collector_cls.get_sample_results()
+        assert isinstance(sample_results, list)
+        assert len(sample_results) > 0
+
 
 class TestLimits(object):
     def test_limit_knows_its_collector(self, limit_cls):

--- a/tests/testapp/tests/test_integrates_with_django_testrunner.py
+++ b/tests/testapp/tests/test_integrates_with_django_testrunner.py
@@ -3,6 +3,7 @@ from django.contrib.auth.models import Group
 from django.test.utils import get_runner
 from django.utils import six
 from django_performance_testing import test_runner as djpt_test_runner_module
+from django_performance_testing.serializer import Reader
 from freezegun import freeze_time
 import pytest
 from testapp.test_helpers import (override_current_context,
@@ -78,6 +79,22 @@ def test_runner_sets_executing_test_method_as_context():
 
     with override_current_context() as ctx:
         run_testcases_with_django_runner(SomeTestCase, nr_of_tests=1)
+
+
+def test_collected_results_serialized_to_settings_based_filename(settings, tmpfilepath):
+
+    class SomeTestCase(unittest.TestCase):
+        def test_foo(self):
+            assert 'test name' in ctx.data, ctx.data.keys()
+            tests = ctx.data['test name']
+            assert len(tests) == 1
+            assert [str(self)] == tests
+
+    settings.DJPT_DATAFILE_PATH = tmpfilepath
+    with override_current_context() as ctx:
+        run_testcases_with_django_runner(SomeTestCase, nr_of_tests=1)
+    reader = Reader(settings.DJPT_DATAFILE_PATH)
+    assert [] != reader.read_all()
 
 
 class FailsDbLimit(object):

--- a/tests/testapp/tests/test_integrates_with_django_testrunner.py
+++ b/tests/testapp/tests/test_integrates_with_django_testrunner.py
@@ -81,7 +81,8 @@ def test_runner_sets_executing_test_method_as_context():
         run_testcases_with_django_runner(SomeTestCase, nr_of_tests=1)
 
 
-def test_collected_results_serialized_to_settings_based_filename(settings, tmpfilepath):
+def test_collected_results_serialized_to_settings_based_filename(
+        settings, tmpfilepath):
 
     class SomeTestCase(unittest.TestCase):
         def test_foo(self):

--- a/tests/testapp/tests/test_serialization.py
+++ b/tests/testapp/tests/test_serialization.py
@@ -60,7 +60,8 @@ def test_roundtrip_serialization_single_results(
     }
     writer = serializer.Writer(tmpfilepath)
     writer.start()
-    writer.handle_result(sender=sender, results=sample_result, context=context)
+    results_collected.send(
+        sender=sender, results=sample_result, context=context)
     writer.end()
     reader = serializer.Reader(tmpfilepath)
     deserialized = reader.read_all()

--- a/tests/testapp/tests/test_serialization.py
+++ b/tests/testapp/tests/test_serialization.py
@@ -55,7 +55,7 @@ def test_writer_writes_collected_results_fired_between_statt_stop(tmpfilepath):
     reader = serializer.Reader(tmpfilepath)
     deserialized = reader.read_all()
     assert deserialized == [(WithId('after start'), [2], {'after': 'start'})]
-    writer.end()  # dump daa again
+    writer.end()  # dump data again
     reader = serializer.Reader(tmpfilepath)
     deserialized = reader.read_all()
     assert deserialized == \

--- a/tests/testapp/tests/test_serialization.py
+++ b/tests/testapp/tests/test_serialization.py
@@ -48,6 +48,22 @@ def test_writer_writes_collected_results_fired_between_statt_stop(tmpfilepath):
     assert deserialized == [(WithId('after start'), [2], {'after': 'start'})]
 
 
+def test_writer_only_writes_when_end_is_called(tmpfilepath):
+    writer = serializer.Writer(tmpfilepath)
+    writer.start()
+    results_collected.send(
+        sender=WithId('after start'), results=[2],
+        context={'after': 'start'})
+    reader = serializer.Reader(tmpfilepath)
+    deserialized = reader.read_all()
+    try:
+        assert deserialized == []
+    finally:
+        writer.end()
+    deserialized = reader.read_all()
+    assert deserialized == [(WithId('after start'), [2], {'after': 'start'})]
+
+
 @pytest.mark.parametrize('sender_id,sender_type', [
         ('sender_id_1', 'sender_type_1'),
         ('sender_id_2', 'sender_type_2'),

--- a/tests/testapp/tests/test_serialization.py
+++ b/tests/testapp/tests/test_serialization.py
@@ -30,6 +30,15 @@ def sample_result(collector_cls, collector_cls_with_sample_result):
     return result
 
 
+def test_datafile_path_depends_on_setting(settings):
+    assert not hasattr(settings, 'DJPT_DATAFILE_PATH'), 'test assumption'
+    assert serializer.get_datafile_path() == 'djpt.results_collected'
+    settings.DJPT_DATAFILE_PATH = 'foo.log'
+    assert serializer.get_datafile_path() == 'foo.log'
+    settings.DJPT_DATAFILE_PATH = 'bar'
+    assert serializer.get_datafile_path() == 'bar'
+
+
 def test_writer_writes_collected_results_fired_between_statt_stop(tmpfilepath):
     writer = serializer.Writer(tmpfilepath)
     results_collected.send(

--- a/tests/testapp/tests/test_serialization.py
+++ b/tests/testapp/tests/test_serialization.py
@@ -46,6 +46,12 @@ def test_writer_writes_collected_results_fired_between_statt_stop(tmpfilepath):
     reader = serializer.Reader(tmpfilepath)
     deserialized = reader.read_all()
     assert deserialized == [(WithId('after start'), [2], {'after': 'start'})]
+    writer.end()  # dump daa again
+    reader = serializer.Reader(tmpfilepath)
+    deserialized = reader.read_all()
+    assert deserialized == \
+        [(WithId('after start'), [2], {'after': 'start'})], \
+        'after first writer.end it should have disonnected the signal'
 
 
 def test_writer_only_writes_when_end_is_called(tmpfilepath):

--- a/tests/testapp/tests/test_serialization.py
+++ b/tests/testapp/tests/test_serialization.py
@@ -33,13 +33,16 @@ def sample_result(collector_cls, collector_cls_with_sample_result):
         ('sender_id_1', 'sender_type_1'),
         ('sender_id_2', 'sender_type_2'),
     ])
-def test_roundtrip_serialization(
+def test_roundtrip_serialization_single_results(
         tmpfilepath, sender_id, sender_type, sample_result):
     sender = FakeSender(id_=sender_id, type_name=sender_type)
+    context = {
+        'setUp method': ['setUp (some.module.TestCase'],
+    }
     writer = serializer.Writer(tmpfilepath)
     writer.start()
-    writer.handle_result(sender=sender, result=sample_result)
+    writer.handle_result(sender=sender, result=sample_result, context=context)
     writer.end()
     reader = serializer.Reader(tmpfilepath)
     deserialized = reader.read_all()
-    assert deserialized == [(sender, sample_result)]
+    assert deserialized == [(sender, sample_result, context)]

--- a/tests/testapp/tests/test_serialization.py
+++ b/tests/testapp/tests/test_serialization.py
@@ -60,7 +60,7 @@ def test_roundtrip_serialization_single_results(
     }
     writer = serializer.Writer(tmpfilepath)
     writer.start()
-    writer.handle_result(sender=sender, result=sample_result, context=context)
+    writer.handle_result(sender=sender, results=sample_result, context=context)
     writer.end()
     reader = serializer.Reader(tmpfilepath)
     deserialized = reader.read_all()

--- a/tests/testapp/tests/test_serialization.py
+++ b/tests/testapp/tests/test_serialization.py
@@ -1,0 +1,45 @@
+import pytest
+from django_performance_testing import serializer
+from testapp.test_helpers import FakeSender
+
+
+def pytest_generate_tests(metafunc):
+    if 'collector_cls_with_sample_result' in metafunc.fixturenames:
+        plugin_cls_fixtures = metafunc._arg2fixturedefs['collector_cls']
+        assert len(plugin_cls_fixtures) == 1
+        plugin_cls_fixture = plugin_cls_fixtures[0]
+        sample_results = []
+        ids = []
+        for collector_cls in plugin_cls_fixture.params:
+            for i, sample in enumerate(collector_cls.get_sample_results()):
+                sample_results.append((collector_cls, sample))
+                ids.append('-sample{}-'.format(i))
+        metafunc.parametrize(
+            argnames='collector_cls_with_sample_result',
+            argvalues=sample_results,
+            ids=ids
+        )
+
+
+@pytest.fixture
+def sample_result(collector_cls, collector_cls_with_sample_result):
+    if collector_cls != collector_cls_with_sample_result[0]:
+        pytest.skip('this sample result is not for this plugin')
+    result = collector_cls_with_sample_result[-1]
+    return result
+
+
+@pytest.mark.parametrize('sender_id,sender_type', [
+        ('sender_id_1', 'sender_type_1'),
+        ('sender_id_2', 'sender_type_2'),
+    ])
+def test_roundtrip_serialization(
+        tmpfilepath, sender_id, sender_type, sample_result):
+    sender = FakeSender(id_=sender_id, type_name=sender_type)
+    writer = serializer.Writer(tmpfilepath)
+    writer.start()
+    writer.handle_result(sender=sender, result=sample_result)
+    writer.end()
+    reader = serializer.Reader(tmpfilepath)
+    deserialized = reader.read_all()
+    assert deserialized == [(sender, sample_result)]

--- a/tests/testapp/tests/test_worst_report.py
+++ b/tests/testapp/tests/test_worst_report.py
@@ -2,21 +2,21 @@ import pytest
 from django.utils import six
 from django_performance_testing.core import NameValueResult
 from django_performance_testing.reports import WorstReport, Result
-from django_performance_testing.signals import results_collected
+from django_performance_testing.signals import results_read
 from testapp.test_helpers import WithId, FakeSender
 
 
 def test_has_worst_value_and_its_context():
     report = WorstReport()
-    results_collected.send(
+    results_read.send(
         sender=WithId('id'), results=[4], context={'first': 'context'})
     assert len(report.data) == 1
     assert (4, {'first': 'context'}) == get_value_and_context(report, 'id')
-    results_collected.send(
+    results_read.send(
         sender=WithId('id'), results=[7], context={'2nd': 'context'})
     assert len(report.data) == 1
     assert (7, {'2nd': 'context'}) == get_value_and_context(report, 'id')
-    results_collected.send(
+    results_read.send(
         sender=WithId('id'), results=[5], context={'3rd': 'context'})
     assert len(report.data) == 1
     assert (7, {'2nd': 'context'}) == get_value_and_context(report, 'id')
@@ -25,7 +25,7 @@ def test_has_worst_value_and_its_context():
 def test_has_copy_of_the_context():
     report = WorstReport()
     sent_context = {'sent': 'context'}
-    results_collected.send(
+    results_read.send(
         sender=WithId('foo'), results=[4], context=sent_context)
     assert len(report.data) == 1
     r_val, r_context = get_value_and_context(report, 'foo')
@@ -37,9 +37,9 @@ def test_has_copy_of_the_context():
 
 def test_handles_multiple_sender_ids_as_separate_items():
     report = WorstReport()
-    results_collected.send(
+    results_read.send(
         sender=WithId('id one'), results=['a'], context={'context': 'one'})
-    results_collected.send(
+    results_read.send(
         sender=WithId('id two'), results=['z'], context={'context': 'two'})
     assert len(report.data) == 2
     assert ('a', {'context': 'one'}) == get_value_and_context(report, 'id one')

--- a/tests/testapp/tests/test_worst_report_integrates_with_django_testrunner.py
+++ b/tests/testapp/tests/test_worst_report_integrates_with_django_testrunner.py
@@ -32,10 +32,15 @@ def packaged_runner(db):
     return get_packaged_runner_with_options
 
 
-def test_report_is_printed_after_test_is_run(packaged_runner):
+def test_notice_is_printed_on_how_to_get_the_worst_report_after_test_run(
+        packaged_runner, settings):
+    settings.DJPT_PRINT_WORST_REPORT = True
     test_run = packaged_runner()
     report = get_report_text()
-    assert test_run["output"].endswith(report)
+    assert not test_run["output"].endswith(report)
+    notice = 'To see the Worst Performing Items report, ' \
+             'run manage.py djpt_worst_report'
+    assert notice in test_run["output"]
 
 
 def test_no_report_is_printed_with_print_report_set_to_false(

--- a/tests/testapp/tests/test_worst_report_integrates_with_django_testrunner.py
+++ b/tests/testapp/tests/test_worst_report_integrates_with_django_testrunner.py
@@ -1,6 +1,6 @@
 from django.contrib.auth.models import Group
 from django_performance_testing.reports import WorstReport
-from django_performance_testing.signals import results_collected
+from django_performance_testing.signals import results_read
 from testapp.test_helpers import WithId, run_testcases_with_django_runner
 import pytest
 import unittest
@@ -11,12 +11,12 @@ def packaged_runner(db):
     class SampleTestCase(unittest.TestCase):
 
         def test_whatever_one(self):
-            results_collected.send(
+            results_read.send(
                 sender=WithId('whatever'), results=[1],
                 context={'test': 'one'})
 
         def test_whatever_two(self):
-            results_collected.send(
+            results_read.send(
                 sender=WithId('whatever'), results=[2],
                 context={'test': 'two'})
 


### PR DESCRIPTION
the combining the output from multiple  runs (e.g.: parallel execution) should be in a different MR, as it is already large enough