### PR TITLE
Fix test_captures_and_measures_elapsed_time

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -208,6 +208,8 @@ as the app has defaults that include all limits.
 
 Release Notes
 =============
+
+* 0.7.1 - bugfix a test
 * 0.7.0 - separate data collection and reporting
 
   * introduce ``djpt_worst_report`` management command

--- a/django_performance_testing/__init__.py
+++ b/django_performance_testing/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.7.0'
+__version__ = '0.7.1'
 
 default_app_config = \
     'django_performance_testing.apps.DjangoPerformanceTestingAppConfig'

--- a/tests/testapp/tests/test_timer_collector.py
+++ b/tests/testapp/tests/test_timer_collector.py
@@ -12,4 +12,4 @@ def test_captures_and_measures_elapsed_time(seconds):
             with TimeCollector():
                 frozen_time.tick(timedelta(seconds=seconds))
     assert len(captured.calls) == 1
-    assert pytest.approx(seconds) == captured.calls[0]['results']
+    assert pytest.approx(seconds) == captured.calls[0]['results'][0].value


### PR DESCRIPTION
Failed with:

```
>       return abs(self.expected - actual) <= self.tolerance
E       TypeError: unsupported operand type(s) for -: 'float' and 'list'
```