### PR TITLE
Bump to 0.7.3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -209,7 +209,7 @@ as the app has defaults that include all limits.
 Release Notes
 =============
 
-* 0.7.2 - conform to latest flake8
+* 0.7.3 - conform to latest flake8
 * 0.7.1 - bugfix a test
 * 0.7.0 - separate data collection and reporting
 

--- a/django_performance_testing/__init__.py
+++ b/django_performance_testing/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.7.2'
+__version__ = '0.7.3'
 
 default_app_config = \
     'django_performance_testing.apps.DjangoPerformanceTestingAppConfig'


### PR DESCRIPTION
 as 0.7.2 is already published and cant be overwritten. may just be our internal CI going nuts.