### PR TITLE
Drop python3.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,5 @@ matrix:
       env: TOX_ENVS=py36-django111
     - python: "3.5"
       env: TOX_ENVS=py35-django18,py35-django19,py35-django110,py35-django111
-    - python: "3.3"
-      env: TOX_ENVS=py33-django18
 script:
   - tox -e $TOX_ENVS

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 # based on https://docs.djangoproject.com/en/1.10/faq/install/#what-python-version-can-i-use-with-django
 [tox]
 envlist =
-   py{27,33,34,35}-django18,
-   py{27,34,35}-django19,
-   py{27,34,35}-django110,
+   py{27,34,35}-django18,
+   py{27,34,35.36}-django19,
+   py{27,34,35,36}-django110,
    py{27,34,35,36}-django111,
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 [tox]
 envlist =
    py{27,34,35}-django18,
-   py{27,34,35.36}-django19,
-   py{27,34,35,36}-django110,
+   py{27,34,35}-django19,
+   py{27,34,35}-django110,
    py{27,34,35,36}-django111,
 
 [testenv]


### PR DESCRIPTION
Since all builds will travis will fail with python3.3 since the wheel is no longer supporting is I suggest we drop it before starting with to the upgrade to django2.0