### PR TITLE
Fix issues in tox run 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ output/*/index.html
 docs/_build
 readme-errors
 djpt.results_collected
+
+# Virtual env supports
+.python-version

--- a/tests/testapp/tests/test_core_infrastructure.py
+++ b/tests/testapp/tests/test_core_infrastructure.py
@@ -76,8 +76,8 @@ class TestCollectors(object):
         listeners = [
             first_attached_handler, second_handler_that_will_fail,
             last_attached_handler]
-        for l in listeners:
-            results_collected.connect(l)
+        for listener in listeners:
+            results_collected.connect(listener)
         try:
             with pytest.raises(MyException) as excinfo:
                 with collector:
@@ -88,8 +88,8 @@ class TestCollectors(object):
             assert first_attached_handler.called
             assert last_attached_handler.called
         finally:
-            for l in listeners:
-                results_collected.disconnect(l)
+            for listener in listeners:
+                results_collected.disconnect(listener)
 
     def test_signal_handler_error_doesnt_hide_orig_error(self, collector_cls):
         collector = collector_cls()

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 # based on https://docs.djangoproject.com/en/1.10/faq/install/#what-python-version-can-i-use-with-django
 [tox]
 envlist =
-   py{27,34,35}-django18,
-   py{27,34,35}-django19,
-   py{27,34,35}-django110,
-   py{27,34,35,36}-django111,
+   python{2.7,3.4,3.5}-django18,
+   python{2.7,3.4,3.5}-django19,
+   python{2.7,3.4,3.5}-django110,
+   python{2.7,3.4,3.5,3.6}-django111,
 
 [testenv]
 commands =
@@ -14,13 +14,12 @@ setenv =
     DJANGO_SETTINGS_MODULE = settings
     PIP_INDEX_URL = https://pypi.python.org/simple/
 deps =
-    py27: mock
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<1.12
+    django{18,19,110,111}: pytest-django>=3,<4
     flake8
-    pytest-django
     docutils
     freezegun
 whitelist_externals = make


### PR DESCRIPTION
- Issue 1 - Tox takes latest version for ‘[[pytest-django](https://pytest-django.readthedocs.io/en/latest/changelog.html#v4-5-2-2021-12-07)](https://pytest-django.readthedocs.io/en/latest/changelog.html#v4-5-2-2021-12-07)’. Not compatible with earlier django versions
    
    ```python
    ======================================================================================== test session starts =========================================================================================
    platform darwin -- Python 3.5.10, pytest-6.1.2, py-1.11.0, pluggy-0.13.1
    cachedir: .tox/python2.7-django18/.pytest_cache
    django: settings: settings (from env)
    rootdir: /Users/xxx/workspace/django-performance-testing
    plugins: django-4.5.2
    collected 263 items
    
    tests/testapp/tests/test_integrates_with_django_test_client.py EEEE                                                                                                                            [  1%]
    tests/testapp/tests/test_integrates_with_django_testrunner.py EEEEEEEEEE                                                                                                                       [  5%]
    tests/testapp/tests/test_integrates_with_template_rendering.py E                                                                                                                               [  5%]
    tests/testapp/tests/test_query_collector.py EEEEEEEEE                                                                                                                                          [  9%]
    tests/testapp/tests/test_querycount_limits.py EE                                                                                                                                               [  9%]
    tests/testapp/tests/test_worst_report_integrates_with_django_testrunner.py EEEE                                                                                                                [ 11%]
    tests/testapp/tests/test_can_classify_queries_into_read_and_write_other.py EEEEEEEEEEE                                                                                                         [ 15%]
    tests/testapp/tests/test_core_constructing_a_registry.py EEEEEE                                                                                                                                [ 17%]
    tests/testapp/tests/test_core_context.py EEEEEE                                                                                                                                                [ 20%]
    tests/testapp/tests/test_core_infrastructure.py EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE                                                           [ 52%]
    tests/testapp/tests/test_core_settings_based_registry.py EEEEEEE                                     
    
    =============================================================================================== ERRORS ===============================================================================================
    ______________________________________ ERROR at setup of test_can_specify_limits_through_settings_for_django_test_client[GET-4-5-queries-queries-DbQueriesView] ______________________________________
    
    request = <SubRequest 'django_test_environment' for <Function test_can_specify_limits_through_settings_for_django_test_client[GET-4-5-queries-queries-DbQueriesView]>>
    
        @pytest.fixture(autouse=True, scope="session")
        def django_test_environment(request) -> None:
    >           setup_test_environment(debug=debug)
    E           TypeError: setup_test_environment() got an unexpected keyword argument 'debug'
    ```
    
- Issue 2 - Py27 like short names unable to span environments
    
    ```python
    ERROR:  py27-django18-pytest3: InterpreterNotFound: python2.7
    ERROR:  py34-django18-pytest3: InterpreterNotFound: python3.4
      py35-django18-pytest3: commands succeeded
    ERROR:  py27-django19-pytest3: InterpreterNotFound: python2.7
    ERROR:  py34-django19-pytest3: InterpreterNotFound: python3.4
      py35-django19-pytest3: commands succeeded
    ERROR:  py27-django110-pytest3: InterpreterNotFound: python2.7
    ERROR:  py34-django110-pytest3: InterpreterNotFound: python3.4
    ```
    
    Cause:
    
    1. Tox unable to link shorter names to specific python version. Problem could be with underlying virtual-environment (i use pyenv) & how tox maps the shorter environment. Have to explore more on Tox [wip].
    2. Similar issue https://github.com/tox-dev/tox/issues/378 -  but circumvented with longer names like python2.7 for py27. 
- Issue 3 - Ambiguous naming - Usage of ‘l’. Flake’s error
    
    ```python
    flake8 django_performance_testing tests proof-of-concepts
    tests/testapp/tests/test_core_infrastructure.py:79:13: E741 ambiguous variable name 'l'
    tests/testapp/tests/test_core_infrastructure.py:91:17: E741 ambiguous variable name 'l'
    make: *** [lint] Error 1
    ERROR: InvocationError for command /usr/bin/make test lint docs (exited with code 2)
    ```
    
    Cause:
    
    - https://www.flake8rules.com/rules/E741.html
        
        <aside>        
        Variables named `I`, `O`, and `l` can be very hard to read. This is because the letter `I` and the letter `l` are easily confused, and the letter `O` and the number `0` can be easily confused.
        </aside>